### PR TITLE
Feature bugfix packagejson error

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,6 @@
         "TextEditor",
         "TextEditor.Buffer",
         "TextEditor.Commands",
-        "TextEditor.Option",
         "TextEditor.KeyBind"
     ],
     "dependencies": {

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.0",
     "summary": "Simple text editor widget",
     "repository": "https://github.com/minekoa/elm-text-editor.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
+    "version": "1.0.1",
+    "summary": "Simple text editor widget",
     "repository": "https://github.com/minekoa/elm-text-editor.git",
     "license": "BSD3",
     "native-modules": true,
@@ -11,6 +11,7 @@
         "TextEditor",
         "TextEditor.Buffer",
         "TextEditor.Commands",
+        "TextEditor.Option",
         "TextEditor.KeyBind"
     ],
     "dependencies": {

--- a/src/TextEditor/Option.elm
+++ b/src/TextEditor/Option.elm
@@ -1,0 +1,32 @@
+module TextEditor.Option exposing
+    ( Option
+    , defaulOptions
+    )
+{-|
+@docs Option, defaulOptions
+
+-}
+
+
+{-| Editor Options, for Command and Rendering
+-}
+type alias Option =
+    { tabOrder : Int
+    , indentTabsMode : Bool
+    , showControlCharactor : Bool
+    }
+
+{-| Create Editor Options by default.
+
+* tabOrder = 4
+* indentTabsMode = False
+* showControlCharactor = False
+-}
+defaulOptions : Option
+defaulOptions =
+    { tabOrder = 4
+    , indentTabsMode = False
+    , showControlCharactor = False
+    }
+
+    


### PR DESCRIPTION
elm-install して elm-make すると

> The elm-package.json constraints of 'minekoa/elm-text-editor' are probably
> letting too much stuff through. Definitely open an issue on the relevant github
> repo to get this fixed and save other people from this pain.
> 
> In the meantime, take a look through the direct dependencies of the broken
> package and see if any of them have had releases recently. If you find the new
> thing that is causing problems, you can artificially constrain things by adding
> some extra constraints to your elm-package.json as a stopgap measure.


と怒られるようになった問題